### PR TITLE
fixes adding flash to mapbox

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ Flash.prototype = mapboxgl.util.inherit(mapboxgl.Control, {
 });
 
 if (window.mapboxgl) {
-  mapboxgl.Flash = Flash;
+  window.mapboxgl.Flash = Flash;
 } else if (typeof module !== 'undefined') {
   module.exports = Flash;
 }


### PR DESCRIPTION
using `mapboxgl.Flash()` will fail with `TypeError: mapboxgl.Flash is not a constructor`

This change fixes it for me.
